### PR TITLE
fix: file location based pat for `bot_env_vars.env` and `../db/prod/*`

### DIFF
--- a/chatbot/config.py
+++ b/chatbot/config.py
@@ -2,7 +2,7 @@ import os
 
 from dotenv import load_dotenv
 
-load_dotenv("bot_env_vars.env")
+load_dotenv(os.path.join(os.path.dirname(__file__), "bot_env_vars.env"))
 
 
 class Config:

--- a/chatbot/db.py
+++ b/chatbot/db.py
@@ -14,9 +14,7 @@ from sqlalchemy.exc import IntegrityError
 # TODO: we might want to have a list of available commands somewhere in the class so that we can
 # quickly check before updating so that we don't crash.
 class DbConnector:
-    def __init__(
-        self, db_path: str = os.path.join(os.path.dirname(__file__), "../db/prod/")
-    ):
+    def __init__(self, db_path: str = os.path.join(os.path.dirname(__file__), "../db/prod/")):
 
         self.db_path = db_path
         os.makedirs(self.db_path, exist_ok=True)

--- a/chatbot/db.py
+++ b/chatbot/db.py
@@ -14,7 +14,9 @@ from sqlalchemy.exc import IntegrityError
 # TODO: we might want to have a list of available commands somewhere in the class so that we can
 # quickly check before updating so that we don't crash.
 class DbConnector:
-    def __init__(self, db_path: str = "../db/prod/"):
+    def __init__(
+        self, db_path: str = os.path.join(os.path.dirname(__file__), "../db/prod/")
+    ):
 
         self.db_path = db_path
         os.makedirs(self.db_path, exist_ok=True)


### PR DESCRIPTION
Hey @bastienboutonnet,

Yesterday in the stream you encountered the problem that you had to rename the chatbot.py file and a lot of messy changes to imports were necessary to get the chatbot working again.

**Today I found what the problem was.**

--> Besides the PATH change for `../db/prod/`, you also had to adjust the path for `bot_env_vars.env`.

The change I present you here is live tested with my own bot. :+1:

I used `black` (of course) to refactor both files. :slightly_smiling_face:

Regards,
Ben