### PR TITLE
feat: allow users to set their country emoji

### DIFF
--- a/chatbot/commands.py
+++ b/chatbot/commands.py
@@ -111,6 +111,22 @@ class SetSourceCommand(BaseCommand):
         self.db_connector.update_command(command_name="source", command_response=self.source_text)
 
 
+class SetUserCountryCommand(BaseCommand):
+    def __init__(self, db_connector: DbConnector, command_input: str, **kwargs):
+        super().__init__(db_connector)
+        self.user_id = kwargs.get("user_id")
+        self.user_country = command_input.lower()
+
+    def run(self):
+        try:
+            assert self.user_id is not None
+            self.db_connector.update_user_country(
+                user_id=self.user_id, user_country=self.user_country
+            )
+        except AssertionError:
+            return None
+
+
 AVAILABLE_COMMANDS: Dict[str, Type[BaseCommand]] = {
     "hello": SayHelloCommand,  # type: ignore
     "commands": ListCommandsCommand,
@@ -120,6 +136,7 @@ AVAILABLE_COMMANDS: Dict[str, Type[BaseCommand]] = {
     "source": SourceCommand,
     "settsource": SetSourceCommand,
     "uptime": UptimeCommand,
+    "setcountry": SetUserCountryCommand,
 }
 COMMANDS_TO_IGNORE: List[str] = ["drop", "keyboard", "dj", "frittata", "work", "discord"]
 

--- a/tests/test_Commands.py
+++ b/tests/test_Commands.py
@@ -9,6 +9,7 @@ from chatbot.commands import (
     SayHelloCommand,
     SetSourceCommand,
     SetTodayCommand,
+    SetUserCountryCommand,
     SourceCommand,
     TodayCommand,
 )
@@ -32,7 +33,10 @@ def test_SayHelloCommand(datafiles):
 def test_ListCommandsCommand(datafiles):
     connector = DbConnector(db_path=datafiles)
     cmd = ListCommandsCommand(connector)
-    assert cmd.run() == "!hello !commands !today !settoday !bot !source !settsource !uptime"
+    assert (
+        cmd.run()
+        == "!hello !commands !today !settoday !bot !source !settsource !uptime !setcountry"
+    )
     assert cmd.is_restricted is False
 
 
@@ -85,6 +89,19 @@ def test_SetTodayCommand(datafiles):
     assert today_text is not None
     assert today_text.split("|")[1].strip() == expectation
     assert set_cmd.is_restricted == True
+
+
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_SetUserCountryCommand(datafiles):
+    expectation = "france"
+    connector = DbConnector(db_path=datafiles)
+    connector.add_new_user(user_id="999", user_name="test_user")
+
+    set_cmd = SetUserCountryCommand(connector, command_input=expectation, user_id="999")
+    set_cmd.run()
+
+    user_country = connector.get_user_country(user_id="999")
+    assert user_country == expectation
 
 
 @pytest.mark.dependency(depends=["test_SourceCommand"])


### PR DESCRIPTION
Resolves #18 

Adds ability for users to do `!setcountry <country>` and have their country string generate a `rich` emoji next to their name which should render as an emoji in the terminal.

If the emoji text does not exist in `rich` then it will not be printed.

This also introduces the addition of a `users` table to which users are added as they first speak in the chat.
